### PR TITLE
Specific now works with Clojure 1.10, 1.9, and 1.8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _Specific_ can generate mock functions from [clojure.spec](http://clojure.org/ab
 
 ## Dependencies
 
-_Specific_ depends on Clojure 1.9 (or 1.8 with the [clojure.spec backport](https://github.com/tonsky/clojure-future-spec)) and [test.check](https://github.com/clojure/test.check) version 0.9.0.
+_Specific_ works with Clojure 1.10 or 1.9 (or 1.8 with the [clojure.spec backport](https://github.com/tonsky/clojure-future-spec)) and [test.check](https://github.com/clojure/test.check) version 0.9.0.
 
 You can find the latest version in the Clojars repository, here:
 
@@ -193,6 +193,9 @@ _Specific_ gets along well with the following tools:
 
 ## Changelog
 
+0.7.0
+  * No longer enforces that a spec specifies a return value when mocking a function
+
 0.6.0
   * More sensible error messages when you forget to mock a function
 
@@ -204,6 +207,16 @@ _Specific_ gets along well with the following tools:
 0.4.0 
   * Generated values are now deterministic
   * Added core/generate to generate test data
+
+## Developing
+
+The following commands run the tests against various versions of Clojure.
+
+```clojure
+lein with-profile +1.10 test
+lein with-profile +1.9 test
+lein with-profile +1.8 test
+```
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,15 @@
-(defproject com.benrady/specific "0.5.1"
+(defproject com.benrady/specific "0.5.1-SNAPSHOT"
   :url "https://github.com/benrady/specific"
   :description "Generate mocks and other test doubles using clojure.spec"
-  :profiles {:dev 
-             {:plugins [[com.jakemccrary/lein-test-refresh "0.18.0"]]
-              :dependencies [[org.clojure/clojure "1.8.0"]
-                             [clojure-future-spec "1.9.0-alpha13"]
-                             [pjstadig/humane-test-output "0.8.1"]
-                             [org.mockito/mockito-core "1.9.5"]
-                             [cljito "0.2.1"]]
-              :injections [(require 'pjstadig.humane-test-output) (pjstadig.humane-test-output/activate!)]
-             }}
+  :profiles {:dev {:plugins [[com.jakemccrary/lein-test-refresh "0.23.0"]]
+                   :dependencies [[pjstadig/humane-test-output "0.8.1"]
+                                  [org.mockito/mockito-core "1.9.5"]
+                                  [cljito "0.2.1"]]
+                   :injections [(require 'pjstadig.humane-test-output) (pjstadig.humane-test-output/activate!)]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
+                                  [clojure-future-spec "1.9.0"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]}}
   :test-paths ["test"]
   :dependencies [[org.clojure/test.check "0.9.0"]]
   :license {:name "GNU Public License v2"

--- a/src/specific/core.clj
+++ b/src/specific/core.clj
@@ -1,5 +1,5 @@
 (ns specific.core
-  (:require [clojure.spec :as spec]
+  (:require [clojure.spec.alpha :as spec]
             [specific
              [gene :as gene]
              [matchers :as matchers]

--- a/src/specific/gene.clj
+++ b/src/specific/gene.clj
@@ -3,7 +3,7 @@
             [clojure.test.check.rose-tree :as rose]
             [clojure.test.check :as check]
             [clojure.test.check.generators :as gen]
-            [clojure.spec :as spec]))
+            [clojure.spec.alpha :as spec]))
 
 (def ^:dynamic *gen-overrides* {})
 

--- a/src/specific/matchers.clj
+++ b/src/specific/matchers.clj
@@ -1,5 +1,5 @@
 (ns specific.matchers
-  (:require [clojure.spec :as spec]
+  (:require [clojure.spec.alpha :as spec]
             [clojure.test :as ctest]))
 
 (defn- conform-or-explain [spc act]

--- a/src/specific/test_double.clj
+++ b/src/specific/test_double.clj
@@ -2,8 +2,8 @@
   (:require [specific.gene :as gene]
             [clojure.string :as string]
             [clojure.test :as ctest]
-            [clojure.spec.test :as stest]
-            [clojure.spec :as spec]))
+            [clojure.spec.test.alpha :as stest]
+            [clojure.spec.alpha :as spec]))
 
 (defn- report-fail [m]
   (ctest/do-report (assoc m :type :fail)))
@@ -63,12 +63,6 @@
    :expected (str "clojure.spec for " fn-sym) 
    :actual nil})
 
-(defn- no-ret-spec-report [fn-sym]
-  {:type :fail 
-   :message (str "No :ret spec defined")
-   :expected (str "clojure.spec at [:ret] for " fn-sym) 
-   :actual nil})
-
 (defn spy-fn [f]
   (let [fn-spec (spec/get-spec f) 
         calls (atom {})]
@@ -82,11 +76,11 @@
       (add-meta f calls))))
 
 (defn mock-fn [fn-sym]
-  (let [fn-spec (spec/get-spec fn-sym) 
+  (let [fn-spec (spec/get-spec fn-sym)
         calls (atom {})]
     (add-meta (let [call-fn (partial record-calls calls)]
                 (if (nil? fn-spec)
                   (no-spec-report fn-sym)
-                  (if (nil? (:ret fn-spec))
-                    (no-ret-spec-report fn-sym)
-                    (comp (partial validate-and-generate fn-spec) call-fn)))) calls)))
+                  (comp (partial validate-and-generate fn-spec) call-fn)))
+              calls)))
+

--- a/test/specific/core_spec.clj
+++ b/test/specific/core_spec.clj
@@ -1,9 +1,9 @@
 (ns specific.core-spec
   (:require [clojure.java.shell]
             [clojure.test :as ctest] 
-            [clojure.spec.test :as stest]
-            [clojure.spec.gen :as gen]
-            [clojure.spec :as spec]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.spec.alpha :as spec]
             [clojure.string :as string])
   (:use [clojure.test]
         [specific.report-stub]

--- a/test/specific/gene_spec.clj
+++ b/test/specific/gene_spec.clj
@@ -1,5 +1,5 @@
 (ns specific.gene-spec
-  (:require [clojure.spec :as spec]
+  (:require [clojure.spec.alpha :as spec]
             [specific
              [gene :as gene]])
   (:use [clojure.test]))

--- a/test/specific/matchers_spec.clj
+++ b/test/specific/matchers_spec.clj
@@ -1,5 +1,5 @@
 (ns specific.matchers-spec
-  (:require [clojure.spec :as spec]
+  (:require [clojure.spec.alpha :as spec]
             [specific
              [report-stub :as report-stub]
              [test-double :as test-double]

--- a/test/specific/readme_spec.clj
+++ b/test/specific/readme_spec.clj
@@ -1,9 +1,9 @@
 (ns specific.readme-spec
   (:require [clojure.java.shell]
             [clojure.test :as ctest] 
-            [clojure.spec.test :as stest]
-            [clojure.spec.gen :as gen]
-            [clojure.spec :as spec]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.spec.alpha :as spec]
             [clojure.string :as string]
             [specific.test-double]
             [specific.sample :as sample])

--- a/test/specific/sample.clj
+++ b/test/specific/sample.clj
@@ -1,5 +1,5 @@
 (ns specific.sample
-  (:require [clojure.spec]
+  (:require [clojure.spec.alpha :as spec]
             [clojure.java.shell :as shell]
             [clojure.string :as string]))
 
@@ -12,14 +12,14 @@
 (defn some-fun [greeting & names]
   (:out (cowsay (greet greeting names))))
 
-(clojure.spec/def ::exit (clojure.spec/and integer? #(>= % 0) #(< % 256)))
-(clojure.spec/def ::out string?)
-(clojure.spec/def ::fun-greeting string?)
-(clojure.spec/fdef greet :ret ::fun-greeting)
-(clojure.spec/fdef cowsay
-                   :args (clojure.spec/cat :fun-greeting ::fun-greeting)
-                   :ret (clojure.spec/keys :req-un [::out ::exit]))
-(clojure.spec/fdef some-fun
-                   :args (clojure.spec/cat :greeting ::fun-greeting
-                                           :names (clojure.spec/* string?))
-                   :ret string?)
+(spec/def ::exit (spec/and integer? #(>= % 0) #(< % 256)))
+(spec/def ::out string?)
+(spec/def ::fun-greeting string?)
+(spec/fdef greet :ret ::fun-greeting)
+(spec/fdef cowsay
+           :args (spec/cat :fun-greeting ::fun-greeting)
+           :ret (spec/keys :req-un [::out ::exit]))
+(spec/fdef some-fun
+           :args (spec/cat :greeting ::fun-greeting
+                           :names (spec/* string?))
+           :ret string?)

--- a/test/specific/test_double_spec.clj
+++ b/test/specific/test_double_spec.clj
@@ -1,5 +1,5 @@
 (ns specific.test-double-spec
-  (:require [clojure.spec :as spec]
+  (:require [clojure.spec.alpha :as spec]
             [specific
              [matchers :as matchers]
              [sample :as sample]])
@@ -50,19 +50,12 @@
       (testing "returns a value that matches the spec"
         (is (string? (mock ""))))
 
-      (testing "returns a test report if the function spec is missing a return value"
-        (is (= {:type :fail
-                :message "No :ret spec defined" 
-                :expected "clojure.spec at [:ret] for #'specific.test-double-spec/no-ret" 
-                :actual nil} 
-               (mock-fn #'no-ret))))
+      (testing "tracks calls specific to each test context"
+        (is (= [] (matchers/calls mock))))
 
       (testing "returns a test report if the function is missing a spec"
         (is (= {:type :fail 
                 :message "No clojure.spec defined" 
                 :expected "clojure.spec for #'specific.test-double-spec/no-spec" 
                 :actual nil}
-               (mock-fn #'no-spec))))
-
-      (testing "tracks calls specific to each test context"
-        (is (= [] (matchers/calls mock)))))))
+               (mock-fn #'no-spec)))))))


### PR DESCRIPTION
Unfortunately, I couldn't find a way to confirm that a spec specifies
a return value spec. The newer versions of clojure.spec default to
clojure.core/any? so checking for existence of a return spec no longer
works.

You could check to see if the return spec is any? but that could be
the actual return spec so I didn't want to enforce that.

This commit also adds a few different profiles for ease of testing
with different Clojure versions and bumps the lein-test-refresh dependency.